### PR TITLE
24 change tab order of settings screen

### DIFF
--- a/FieldDayLogger.py
+++ b/FieldDayLogger.py
@@ -43,8 +43,6 @@ from database import DataBase
 from cwinterface import CW
 from edittextfield import EditTextField
 from wsjtx_listener import WsjtxListener
-
-# from preferences import Preferences
 from settings import SettingsScreen
 
 
@@ -63,8 +61,8 @@ else:
 # If no preference file exists, one is created from this dictionary.
 preference = {
     "mycall": "Call",
-    "myclass": "Class",
-    "mysection": "Section",
+    "myclass": "",
+    "mysection": "",
     "power": "100",
     "altpower": 0,
     "usehamdb": 0,

--- a/fd_preferences.json
+++ b/fd_preferences.json
@@ -1,7 +1,7 @@
 {
     "mycall": "Call",
-    "myclass": "Class",
-    "mysection": "Section",
+    "myclass": "",
+    "mysection": "",
     "power": "100",
     "altpower": 0,
     "usehamdb": 0,

--- a/settings.py
+++ b/settings.py
@@ -144,9 +144,9 @@ class SettingsScreen:
             self.cloudlogapi,
             self.cloudlogurl,
             self.cloudlogstationid,
-            self.altpower,
             self.cwdaemon,
             self.pywinkeyer,
+            self.altpower,
             self.CW_IP,
             self.CW_port,
         ]


### PR DESCRIPTION
Changed the TAB order of the fields on the settings screen. Moving the Alt-Power bonus.
Removed the default class and section values from the settings JSON file.
The default values did not fit in the on-screen settings field.